### PR TITLE
add windows-specific build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,17 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       with:
         fetch-depth: 0
     - name: Build the package
+      shell: bash
       run: |
         source $CONDA/etc/profile.d/conda.sh
         conda install conda-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
         conda install conda-build
         conda build conda.recipe
         mv $CONDA/conda-bld .
+        # This ensures the noarch repodata.json is not clobbered
+        if [ -d conda-bld/win-64 ]; then rm -rf conda-bld/noarch; fi
     - name: Upload build artifacts
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
         conda config --set solver libmamba
         python tests/test_config.py
         conda config --set solver classic
+        rm -f ~/.condarc || :
     - name: Build an installer
       run: |
         cd tests
@@ -107,11 +108,15 @@ jobs:
       run: |
         cd tests
         start /wait AIDTest-1.0-Windows-x86_64.exe /S /D=%USERPROFILE%\aidtest
+        call %USERPROFILE%\aidtest\Scripts\activate
+        conda info
     - name: Run the installer (Unix)
       if: matrix.os != 'windows-latest'
       run: |
         cd tests
         bash AIDTest*.sh -b -p ~/aidtest -k
+        source ~/aidtest/bin/activate
+        conda info
     - name: Test the installed environment
       run: |
         cd tests

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,13 @@
+echo on
+setlocal EnableDelayedExpansion
+%PREFIX%\python.exe -m pip install --no-deps --ignore-installed -vv .
+if "%NEED_SCRIPTS%" neq "yes" del %SP_DIR%\anaconda_anon_usage\install.py
+if "%NEED_SCRIPTS%" neq "yes" exit
+if not exist %PREFIX%\etc\conda\activate.d mkdir %PREFIX%\etc\conda\activate.d
+if not exist %PREFIX%\python-scripts mkdir %PREFIX%\python-scripts
+copy scripts\post-link.sh   %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.sh
+copy scripts\post-link.bat  %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
+copy scripts\post-link.sh   %PREFIX%\python-scripts\.%PKG_NAME%-post-link.sh
+copy scripts\pre-unlink.sh  %PREFIX%\python-scripts\.%PKG_NAME%-pre-unlink.sh
+copy scripts\post-link.bat  %PREFIX%\python-scripts\.%PKG_NAME%-post-link.bat
+copy scripts\pre-unlink.bat %PREFIX%\python-scripts\.%PKG_NAME%-pre-unlink.bat

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ..
 
 build:
-  noarch: python
+  noarch: python  # [not win]
   script_env:
    - NEED_SCRIPTS=no   # [variant=="plugin"]
    - NEED_SCRIPTS=yes  # [variant=="patch"]

--- a/tests/test_environment.sh
+++ b/tests/test_environment.sh
@@ -33,9 +33,8 @@ echo "$pkgs" | grep -vE '^ *$'
 echo "------------------------"
 
 echo
-export CONDA_ANACONDA_ANON_USAGE=yes
 cmd="$T_PYTHON -m conda info"
-echo "\$ CONDA_ANACONDA_ANON_USAGE=yes $cmd"
+echo "\$ $cmd"
 echo "------------------------"
 cinfo=$($cmd 2>&1)
 echo "$cinfo" | grep -vE '^ *$'

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-vflag="==$1"; shift
+version=$1; shift
+vflag="==$version"
 
 SCRIPTDIR=$(cd $(dirname $BASH_SOURCE[0]) && pwd)
 CONDA_PREFIX=$(cd $CONDA_PREFIX && pwd)


### PR DESCRIPTION
Because we don't build noarch packages on defaults, we need to put a windows-specific build through its full testing here. The patch build in particular requires verification of the activate, pre-link, and post-link scripts.