### PR TITLE
more minor cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
         path: conda-bld/
   test:
     needs: build
+    env:
+      ANACONDA_ANON_USAGE_DEBUG: 1
+      ANACONDA_ANON_USAGE_RAISE: 1
     defaults:
       run:
         shell: bash
@@ -84,8 +87,6 @@ jobs:
       shell: cmd
       run: |
         call testenv\Scripts\activate
-        set ANACONDA_ANON_USAGE_DEBUG=1
-        set ANACONDA_ANON_USAGE_RAISE=1
         conda info 1>output.txt 2>&1 | type output.txt
         find "Error loading" output.txt >nul
         if %errorlevel% equ 0 exit -1
@@ -99,8 +100,6 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         source ./testenv/bin/activate
-        export ANACONDA_ANON_USAGE_DEBUG=1
-        export ANACONDA_ANON_USAGE_RAISE=1
         conda info 2>&1 | tee output.txt
         if grep -q 'Error loading' output.txt; then exit -1; fi
         python tests/test_config.py

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -2,6 +2,7 @@ echo on
 setlocal EnableDelayedExpansion
 %PREFIX%\python.exe -m pip install --no-deps --ignore-installed -vv .
 if "%NEED_SCRIPTS%" neq "yes" del %SP_DIR%\anaconda_anon_usage\install.py
+if "%NEED_SCRIPTS%" equ "yes" del %SP_DIR%\anaconda_anon_usage\plugin.py
 if "%NEED_SCRIPTS%" neq "yes" exit
 if not exist %PREFIX%\etc\conda\activate.d mkdir %PREFIX%\etc\conda\activate.d
 if not exist %PREFIX%\python-scripts mkdir %PREFIX%\python-scripts

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -2,6 +2,8 @@
 if [ "$NEED_SCRIPTS" != yes ]; then
     rm ${SP_DIR}/anaconda_anon_usage/install.py
     exit 0
+else
+    rm ${SP_DIR}/anaconda_anon_usage/plugin.py
 fi
 mkdir -p "${PREFIX}/etc/conda/activate.d"
 mkdir -p "${PREFIX}/python-scripts"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup
 
 import versioneer
@@ -18,7 +20,9 @@ setup(
         "conda": [
             "anaconda-anon-usage-plugin = anaconda_anon_usage.plugin",
         ],
-    },
+    }
+    if os.environ.get("NEED_SCRIPTS") != "yes"
+    else {},
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
- remove the plugin code for the patch variant
- expand the help messages in install.py, in part to help users understand that `python -m anaconda_anon_usage.install --disable` is not an effective way to disable the code
- remove some code in install.py left over from another project
- minor cleanup