### PR TITLE
multithreading fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         source $CONDA/etc/profile.d/conda.sh
         pkg=local::anaconda-anon-usage
         conda install anaconda-client constructor conda-index $pkg
-        if [[ ! "${{ matrix.cversion }}" =~ 4.* ]]; then
+        if [[ "${{ matrix.cversion }}" == 23.7.* ]]; then
           mamba=conda-libmamba-solver
           echo "MAMBA=yes" >> "$GITHUB_ENV"
         fi

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -55,7 +55,7 @@ def environment_token(prefix=None):
     if prefix is None:
         prefix = sys.prefix
     fpath = join(prefix, "etc", "aau_token")
-    return _saved_token(fpath, "environment")
+    return _saved_token(fpath, "environment", prefix)
 
 
 @cached

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -4,18 +4,18 @@
 # conda must be avoided so that this package can be used in
 # child environments.
 
-import functools
 import sys
 from collections import namedtuple
 from os.path import expanduser, join
 
 from . import __version__
-from .utils import _debug, _random_token, _saved_token
+from .utils import _debug, _random_token, _saved_token, cached
 
 Tokens = namedtuple("Tokens", ("version", "client", "session", "environment"))
 CONFIG_DIR = expanduser("~/.conda")
 
 
+@cached
 def version_token():
     """
     Returns the version token, which is just the
@@ -24,7 +24,7 @@ def version_token():
     return __version__
 
 
-@functools.lru_cache(maxsize=None)
+@cached
 def client_token():
     """
     Returns the client token. If a token has not yet
@@ -35,16 +35,16 @@ def client_token():
     return _saved_token(fpath, "client")
 
 
-@functools.lru_cache(maxsize=None)
+@cached
 def session_token():
     """
     Returns the session token, generated randomly for each
     execution of the process.
     """
-    return _random_token()
+    return _random_token("session")
 
 
-@functools.lru_cache(maxsize=None)
+@cached
 def environment_token(prefix=None):
     """
     Returns the environment token for the given prefix, or
@@ -58,7 +58,7 @@ def environment_token(prefix=None):
     return _saved_token(fpath, "environment")
 
 
-@functools.lru_cache(maxsize=None)
+@cached
 def all_tokens(prefix=None):
     """
     Returns the token set, in the form of a Tokens namedtuple.
@@ -69,7 +69,7 @@ def all_tokens(prefix=None):
     )
 
 
-@functools.lru_cache(maxsize=None)
+@cached
 def token_string(prefix=None, enabled=True):
     """
     Returns the token set, formatted into the string that is
@@ -80,7 +80,8 @@ def token_string(prefix=None, enabled=True):
         values = all_tokens(prefix)
         if values.client:
             parts.append("c/" + values.client)
-        parts.append("s/" + values.session)
+        if values.session:
+            parts.append("s/" + values.session)
         if values.environment:
             parts.append("e/" + values.environment)
     else:

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -1,3 +1,4 @@
+import atexit
 import base64
 import os
 import sys
@@ -7,6 +8,13 @@ from threading import RLock
 DPREFIX = os.environ.get("ANACONDA_ANON_USAGE_DEBUG_PREFIX") or ""
 DEBUG = bool(os.environ.get("ANACONDA_ANON_USAGE_DEBUG")) or DPREFIX
 
+# When creating a new environment, the environment token will be
+# created in advance of the action creation of the standard conda
+# directory structure. If we write the token to its location and
+# then the creation is interrupted, the directory will now be in
+# a state where conda is unwilling to install into it, thinking
+# it is a non-empty non-conda directory.
+DEFERRED = []
 
 # While lru_cache is thread safe, it does not prevent two threads
 # from beginning the same computation. This simple cache mechanism
@@ -48,13 +56,46 @@ def _random_token(what="random"):
     return result
 
 
-def _saved_token(fpath, what):
+def _final_attempt():
+    """
+    Called upon the graceful exit from conda, this attempts to
+    write an environment token that was deferred because the
+    environment directory was not yet available.
+    """
+    global DEFERRED
+    for must_exist, fpath, token in DEFERRED:
+        _write_attempt(must_exist, fpath, token)
+
+
+atexit.register(_final_attempt)
+
+
+def _write_attempt(must_exist, fpath, client_token):
+    """
+    Attempt to write the token to the given location.
+    Return True with success, False otherwise.
+    """
+    if must_exist and not exists(must_exist):
+        _debug("Directory not ready: %s", must_exist)
+        return False
+    try:
+        os.makedirs(dirname(fpath), exist_ok=True)
+        with open(fpath, "w") as fp:
+            fp.write(client_token)
+        _debug("Token saved: %s", fpath)
+        return True
+    except Exception as exc:
+        _debug("Unexpected error writing: %s\n  %s", fpath, exc, error=True)
+
+
+def _saved_token(fpath, what, must_exist=None):
     """
     Implements the saved token functionality. If the specified
     file exists, and contains a token with the right format,
     return it. Otherwise, generate a new one and save it in
     this location. If that fails, return an empty string.
     """
+    global DEFERRED
     client_token = ""
     _debug("%s token path: %s", what.capitalize(), fpath)
     if exists(fpath):
@@ -69,12 +110,9 @@ def _saved_token(fpath, what):
         if len(client_token) > 0:
             _debug("Generating longer token")
         client_token = _random_token(what)
-        try:
-            os.makedirs(dirname(fpath), exist_ok=True)
-            with open(fpath, "w") as fp:
-                fp.write(client_token)
-            _debug("%s token saved: %s", what.capitalize(), fpath)
-        except Exception as exc:
-            _debug("Unexpected error writing: %s\n  %s", fpath, exc, error=True)
-            client_token = ""
+        if not _write_attempt(must_exist, fpath, client_token):
+            # If the environment has not yet been created we need
+            # to defer the token write until later.
+            _debug("Deferring token write")
+            DEFERRED.append((must_exist, fpath, client_token))
     return client_token

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -31,12 +31,17 @@ def cached(func):
     return call_if_needed
 
 
+def _cache_clear():
+    global CACHE
+    CACHE.clear()
+
+
 def _debug(s, *args, error=False):
     if error or DEBUG:
         print((DPREFIX + s) % args, file=sys.stderr)
 
 
-def _random_token(what):
+def _random_token(what="random"):
     data = os.urandom(16)
     result = base64.urlsafe_b64encode(data).strip(b"=").decode("ascii")
     _debug("Generated %s token: %s", what, result)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
 test:
   requires:
     - conda
+    - pytest
+    - pytest-cov
   source_files:
     - tests
   commands:
@@ -35,6 +37,7 @@ test:
     - set ANACONDA_ANON_USAGE_DEBUG=1  # [win]
     - conda info
     - python -m anaconda_anon_usage.install --status  # [variant=="patch"]
+    - pytest -v tests/unit
     - python tests/integration/test_config.py
 
 about:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,9 @@ test:
     - tests
   commands:
     - export ANACONDA_ANON_USAGE_DEBUG=1  # [unix]
+    - export PYTHONUNBUFFERED=1  # [unix]
     - set ANACONDA_ANON_USAGE_DEBUG=1  # [win]
+    - set PYTHONUNBUFFERED=1 # [win]
     - conda info
     - python -m anaconda_anon_usage.install --status  # [variant=="patch"]
     - pytest -v tests/unit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from conda.base.context import Context
 
 from anaconda_anon_usage import tokens
+from anaconda_anon_usage.utils import _cache_clear
 
 
 @pytest.fixture
@@ -23,17 +24,9 @@ def token_cleanup(request, aau_token_path):
     request.addfinalizer(_remove)
 
 
-def clear_cache():
-    tokens.client_token.cache_clear()
-    tokens.session_token.cache_clear()
-    tokens.environment_token.cache_clear()
-    tokens.all_tokens.cache_clear()
-    tokens.token_string.cache_clear()
-
-
 @pytest.fixture(autouse=True)
 def client_token_string_cache_cleanup(request):
-    request.addfinalizer(clear_cache)
+    request.addfinalizer(_cache_clear)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,10 +36,9 @@ def test_saved_token_exception(tmpdir):
     token_path = tmpdir.join("aau_token")
     # setting this up as a directory to trigger the exists
     token_path.mkdir()
-    token_saved = utils._saved_token(token_path, "test")
+    utils._saved_token(token_path, "test")
     assert exists(token_path)
     assert isdir(token_path)
-    assert token_saved == ""
 
 
 def test_saved_token_existing_short(tmpdir):


### PR DESCRIPTION
Studying logs during an attempt to build environment token tests, I found that the token computation functions were at least occasionally being run multiple times. In the case of `_saved_token` this can produce multiple tokens with in the same transaction. That is to say, two threads could produce two environment tokens, for instance. Of course, once the token is saved, no conflicts are seen.

One would have thought `lru_cache` would fix this. Not so; the function itself is thread safe but it doesn't guarantee that only one _attempt_ to populate the cache will take place. So to fix this, I've created a simple single-entry cache that uses a lock to ensure only a single attempt to populate the cache is made. 