### PR TITLE
Fix interrupted creation issue

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -55,7 +55,7 @@ def environment_token(prefix=None):
     if prefix is None:
         prefix = sys.prefix
     fpath = join(prefix, "etc", "aau_token")
-    return _saved_token(fpath, "environment")
+    return _saved_token(fpath, "environment", prefix)
 
 
 @cached

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -1,7 +1,7 @@
+import atexit
 import base64
 import os
 import sys
-import atexit
 from os.path import dirname, exists
 from threading import RLock
 
@@ -59,7 +59,7 @@ def _random_token(what="random"):
 def _final_attempt():
     """
     Called upon the graceful exit from conda, this attempts to
-    write an environment token that was deferred becuase the
+    write an environment token that was deferred because the
     environment directory was not yet available.
     """
     global DEFERRED

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,9 @@ test:
     - tests
   commands:
     - export ANACONDA_ANON_USAGE_DEBUG=1  # [unix]
+    - export PYTHONUNBUFFERED=1  # [unix]
     - set ANACONDA_ANON_USAGE_DEBUG=1  # [win]
+    - set PYTHONUNBUFFERED=1 # [win]
     - conda info
     - python -m anaconda_anon_usage.install --status  # [variant=="patch"]
     - pytest -v tests/unit

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,10 +36,9 @@ def test_saved_token_exception(tmpdir):
     token_path = tmpdir.join("aau_token")
     # setting this up as a directory to trigger the exists
     token_path.mkdir()
-    token_saved = utils._saved_token(token_path, "test")
+    utils._saved_token(token_path, "test")
     assert exists(token_path)
     assert isdir(token_path)
-    assert token_saved == ""
 
 
 def test_saved_token_existing_short(tmpdir):


### PR DESCRIPTION
Fixes #21 

[NOTE: this is based off of #20]

```
conda clean --index --yes
conda create -n testchild1 --yes -c https://repo.anaconda.com/pkgs/fakechannel fakepackage
conda install -n testchild1 xz
```

Without this PR, the `install` command will fail with an error that says `$CONDA_ROOT/envs/testchild1` is not a valid conda environment. The `conda clean --index` command is important to reproduce the issue, because if the cache is fresh, no requests to channels will be made, and no token will be generated, so the bug will not be exercised.

With this PR the `install` command will still fail, but because that environment directory doesn't exist. That's the way it should be. You can then do this:

```
conda clean --index --yes
conda create -n testchild1 --yes -c https://repo.anaconda.com/pkgs/fakechannel fakepackage
conda create -n testchild1 xz
```

This works by deferring the creation of the environment token file until exit. Here's what a typical debug log looks like. HOWEVER, note that if the indices are all cached, conda may never attempt to create tokens, so the error won't
```
(base) m1mbp:anaconda-anon-usage mgrant$ ANACONDA_ANON_USAGE_DEBUG=1 conda create -n testchild1
Applying anaconda_anon_usage context patch
Applying anaconda_anon_usage cli.install patch
Collecting package metadata (current_repodata.json): done
Solving environment: done
Client token path: /Users/mgrant/.conda/aau_token
Retrieved client token: dHfzsOSb6GIo5_krE6ykqA
Generated session token: jcLutgUzwPaSR7maIBwkNA
Environment token path: /Users/mgrant/miniconda3/envs/testchild1/etc/aau_token
Generated environment token: _oPYRySJjssKbEe5Gk4vCA
Directory not ready: /Users/mgrant/miniconda3/envs/testchild1
Deferring token write
Full client token: aau/0.3.0+15.g45a4574 c/dHfzsOSb6GIo5_krE6ykqA s/jcLutgUzwPaSR7maIBwkNA e/_oPYRySJjssKbEe5Gk4vCA

## Package Plan ##

  environment location: /Users/mgrant/miniconda3/envs/testchild1



Proceed ([y]/n)? y

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate testchild1
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Token saved: /Users/mgrant/miniconda3/envs/testchild1/etc/aau_token
```